### PR TITLE
Fake change removing GitHub error encoding iso 8859 1

### DIFF
--- a/src/TroykaProximity.h
+++ b/src/TroykaProximity.h
@@ -8,7 +8,6 @@
  * License: GPLv3, all text here must be included in any redistribution.
  */
 
-
 #ifndef __TROYKAPROXIMITY_H__
 #define __TROYKAPROXIMITY_H__
 

--- a/src/TroykaProximity.h
+++ b/src/TroykaProximity.h
@@ -2,7 +2,7 @@
  * This file is a part of Troyka modules library.
  *
  * Defines: Troyka proximity and ambient light library. Uses Adafruit_VL6180X library.
- * � Amperka LLC (https://amperka.com, dev@amperka.com)
+ * © Amperka LLC (https://amperka.com, dev@amperka.com)
  * 
  * Author: Yury Botov <by@amperka.ru>
  * License: GPLv3, all text here must be included in any redistribution.

--- a/src/TroykaProximity.h
+++ b/src/TroykaProximity.h
@@ -2,11 +2,12 @@
  * This file is a part of Troyka modules library.
  *
  * Defines: Troyka proximity and ambient light library. Uses Adafruit_VL6180X library.
- * © Amperka LLC (https://amperka.com, dev@amperka.com)
+ * ï¿½ Amperka LLC (https://amperka.com, dev@amperka.com)
  * 
  * Author: Yury Botov <by@amperka.ru>
  * License: GPLv3, all text here must be included in any redistribution.
  */
+
 
 #ifndef __TROYKAPROXIMITY_H__
 #define __TROYKAPROXIMITY_H__


### PR DESCRIPTION
Fake change: removing GitHub error "encoding iso 8859-1".

В файле оказаласть закопипасченная строка с копирайтом, а у этой строки - \n вместо \n\r.
Гитхаб решил все стандартизовать и нашел эту строку ошибочно решив что у нее неправильная кодировка. Они сделали авторекодинг таких строк в UTF8 "при следующем коммите". Из-за ошибки диагноза (изначальная кодировка была win1251) при перекодировке ломается знак копирайта. Поэтому делаю пустой коммит (добавляю пустую строку), они рекодируют строку. Убираю пустую строку (чтобы все было как раньше). Восстанавливаю сломанный знак копирайта.
Если подтверждается такая схема запущу остальные по аналогии.
